### PR TITLE
Initial commit for integration of HPE OneView resources with Ansible Core

### DIFF
--- a/lib/ansible/module_utils/oneview.py
+++ b/lib/ansible/module_utils/oneview.py
@@ -1,0 +1,771 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (2016-2017) Hewlett Packard Enterprise Development LP
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import (absolute_import,
+                        division,
+                        print_function,
+                        unicode_literals)
+
+from future import standard_library
+import json
+import logging
+import os
+from ansible.module_utils.basic import AnsibleModule
+from copy import deepcopy
+from collections import OrderedDict
+
+standard_library.install_aliases()
+logger = logging.getLogger(__name__)
+
+try:
+    from hpOneView.oneview_client import OneViewClient
+    from hpOneView.exceptions import (HPOneViewException,
+                                      HPOneViewTaskError,
+                                      HPOneViewValueError,
+                                      HPOneViewResourceNotFound)
+
+    HAS_HPE_ONEVIEW = True
+except ImportError:
+    HAS_HPE_ONEVIEW = False
+
+
+class OneViewModuleBase(object):
+    MSG_CREATED = 'Resource created successfully.'
+    MSG_UPDATED = 'Resource updated successfully.'
+    MSG_DELETED = 'Resource deleted successfully.'
+    MSG_ALREADY_PRESENT = 'Resource is already present.'
+    MSG_ALREADY_ABSENT = 'Resource is already absent.'
+    HPE_ONEVIEW_SDK_REQUIRED = 'HPE OneView Python SDK is required for this module.'
+
+    ONEVIEW_COMMON_ARGS = dict(
+        config=dict(required=False, type='str')
+    )
+
+    ONEVIEW_VALIDATE_ETAG_ARGS = dict(
+        validate_etag=dict(
+            required=False,
+            type='bool',
+            default=True)
+    )
+
+    resource_client = None
+
+    def __init__(self, additional_arg_spec=None, validate_etag_support=False):
+        """
+        OneViewModuleBase constructor.
+
+        Args:
+            additional_arg_spec (dict): Additional argument spec definition.
+            validate_etag_support (bool): Enables support to eTag validation.
+        """
+
+        argument_spec = self.__build_argument_spec(additional_arg_spec, validate_etag_support)
+
+        self.module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=False)
+
+        self.__check_hpe_oneview_sdk()
+        self.__create_oneview_client()
+
+        self.state = self.module.params.get('state')
+        self.data = self.module.params.get('data')
+
+        # Preload params for get_all - used by facts
+        self.facts_params = self.module.params.get('params') or {}
+
+        # Preload options as dict - used by facts
+        self.options = self.transform_list_to_dict(self.module.params.get('options'))
+
+        self.validate_etag_support = validate_etag_support
+
+    def __build_argument_spec(self, additional_arg_spec, validate_etag_support):
+
+        merged_arg_spec = dict()
+        merged_arg_spec.update(self.ONEVIEW_COMMON_ARGS)
+
+        if validate_etag_support:
+            merged_arg_spec.update(self.ONEVIEW_VALIDATE_ETAG_ARGS)
+
+        if additional_arg_spec:
+            merged_arg_spec.update(additional_arg_spec)
+
+        return merged_arg_spec
+
+    def __check_hpe_oneview_sdk(self):
+        if not HAS_HPE_ONEVIEW:
+            self.module.fail_json(msg=self.HPE_ONEVIEW_SDK_REQUIRED)
+
+    def __create_oneview_client(self):
+        if not self.module.params['config']:
+            self.oneview_client = OneViewClient.from_environment_variables()
+        else:
+            self.oneview_client = OneViewClient.from_json_file(self.module.params['config'])
+
+    def execute_module(self):
+        """
+        Abstract function, must be implemented by the inheritor.
+
+        This method is called from the run method. It should contains the module logic
+
+        Returns:
+            dict:
+                 It must return a dictionary with the attributes for the module result,
+                 such as ansible_facts, msg and changed.
+        """
+        raise HPOneViewException("execute_module not implemented")
+
+    def run(self):
+        """
+        Common implementation of the OneView run modules.
+        It calls the inheritor 'execute_module' function and sends the return to the Ansible.
+        It handles any HPOneViewException in order to signal a failure to Ansible, with a descriptive error message.
+        """
+        try:
+            if self.validate_etag_support:
+                if not self.module.params.get('validate_etag'):
+                    self.oneview_client.connection.disable_etag_validation()
+
+            result = self.execute_module()
+
+            if "changed" not in result:
+                result['changed'] = False
+
+            self.module.exit_json(**result)
+
+        except HPOneViewException as exception:
+            self.module.fail_json(msg='; '.join(str(e) for e in exception.args))
+
+    def resource_absent(self, resource, method='delete'):
+        """
+        Generic implementation of the absent state for the OneView resources.
+        It checks if the resource needs to be removed.
+        Args:
+            resource (dict): Resource to delete.
+            method (str):
+                Function of the OneView client that will be called for resource deletion. Usually delete or remove.
+
+        Returns:
+            A dictionary with the expected arguments for the AnsibleModule.exit_json
+
+        """
+        if resource:
+            getattr(self.resource_client, method)(resource)
+
+            return {"changed": True, "msg": self.MSG_DELETED}
+        else:
+            return {"changed": False, "msg": self.MSG_ALREADY_ABSENT}
+
+    def get_by_name(self, name):
+        """
+        Generic get by name implementation.
+        Args:
+            name: Resource name to search for.
+
+        Returns:
+            The resource found or None.
+        """
+        result = self.resource_client.get_by('name', name)
+        return result[0] if result else None
+
+    def resource_present(self, resource, fact_name, create_method='create'):
+        """
+        Generic implementation of the present state for the OneView resources.
+        It checks if the resource needs to be created or updated.
+
+        Args:
+            resource (dict):
+                Resource to create or update.
+            fact_name (str):
+                Name of the fact returned to the Ansible.
+            create_method (str):
+                Function of the OneView client that will be called for resource creation. Usually create or add.
+
+        Returns:
+            A dictionary with the expected arguments for the AnsibleModule.exit_json
+        """
+
+        changed = False
+        if "newName" in self.data:
+            self.data["name"] = self.data.pop("newName")
+
+        if not resource:
+            resource = getattr(self.resource_client, create_method)(self.data)
+            msg = self.MSG_CREATED
+            changed = True
+
+        else:
+            merged_data = resource.copy()
+            merged_data.update(self.data)
+
+            if ResourceComparator.compare(resource, merged_data):
+                msg = self.MSG_ALREADY_PRESENT
+            else:
+                resource = self.resource_client.update(merged_data)
+                changed = True
+                msg = self.MSG_UPDATED
+
+        return dict(
+            msg=msg,
+            changed=changed,
+            ansible_facts={fact_name: resource}
+        )
+
+    @staticmethod
+    def transform_list_to_dict(list_):
+        """
+        Transforms a list into a dictionary, putting values as keys.
+
+        Args:
+            list_: List of values
+
+        Returns:
+            dict: dictionary built
+        """
+
+        ret = {}
+
+        if not list_:
+            return ret
+
+        for value in list_:
+            if isinstance(value, dict):
+                ret.update(value)
+            else:
+                ret[str(value)] = True
+
+        return ret
+
+    @staticmethod
+    def get_logger(mod_name):
+        """
+        To activate logs, setup the environment var LOGFILE
+        e.g.: export LOGFILE=/tmp/ansible-oneview.log
+
+        Args:
+            mod_name: module name
+
+        Returns: Logger instance
+        """
+
+        logger = logging.getLogger(os.path.basename(mod_name))
+        global LOGFILE
+        LOGFILE = os.environ.get('LOGFILE')
+        if not LOGFILE:
+            logger.addHandler(logging.NullHandler())
+        else:
+            logging.basicConfig(level=logging.DEBUG, datefmt='%Y-%m-%d %H:%M:%S',
+                                format='%(asctime)s %(levelname)s %(name)s %(message)s',
+                                filename=LOGFILE, filemode='a')
+        return logger
+
+
+class ResourceComparator():
+    MSG_DIFF_AT_KEY = 'Difference found at key \'{0}\'. '
+
+    @staticmethod
+    def compare(first_resource, second_resource):
+        """
+        Recursively compares dictionary contents equivalence, ignoring types and elements order.
+        Particularities of the comparison:
+            - Inexistent key = None
+            - These values are considered equal: None, empty, False
+            - Lists are compared value by value after a sort, if they have same size.
+            - Each element is converted to str before the comparison.
+        Args:
+            first_resource: first dictionary
+            second_resource: second dictionary
+
+        Returns:
+            bool: True when equal, False when different.
+        """
+        resource1 = deepcopy(first_resource)
+        resource2 = deepcopy(second_resource)
+
+        debug_resources = "resource1 = {0}, resource2 = {1}".format(resource1, resource2)
+
+        # The first resource is True / Not Null and the second resource is False / Null
+        if resource1 and not resource2:
+            logger.debug("resource1 and not resource2. " + debug_resources)
+            return False
+
+        # Checks all keys in first dict against the second dict
+        for key in resource1.keys():
+            if key not in resource2:
+                if resource1[key] is not None:
+                    # Inexistent key is equivalent to exist with value None
+                    logger.debug(ResourceComparator.MSG_DIFF_AT_KEY.format(key) + debug_resources)
+                    return False
+            # If both values are null, empty or False it will be considered equal.
+            elif not resource1[key] and not resource2[key]:
+                continue
+            elif isinstance(resource1[key], dict):
+                # recursive call
+                if not ResourceComparator.compare(resource1[key], resource2[key]):
+                    logger.debug(ResourceComparator.MSG_DIFF_AT_KEY.format(key) + debug_resources)
+                    return False
+            elif isinstance(resource1[key], list):
+                # change comparison function to compare_list
+                if not ResourceComparator.compare_list(resource1[key], resource2[key]):
+                    logger.debug(ResourceComparator.MSG_DIFF_AT_KEY.format(key) + debug_resources)
+                    return False
+            elif ResourceComparator._standardize_value(resource1[key]) != ResourceComparator._standardize_value(
+                    resource2[key]):
+                logger.debug(ResourceComparator.MSG_DIFF_AT_KEY.format(key) + debug_resources)
+                return False
+
+        # Checks all keys in the second dict, looking for missing elements
+        for key in resource2.keys():
+            if key not in resource1:
+                if resource2[key] is not None:
+                    # Inexistent key is equivalent to exist with value None
+                    logger.debug(ResourceComparator.MSG_DIFF_AT_KEY.format(key) + debug_resources)
+                    return False
+
+        return True
+
+    @staticmethod
+    def compare_list(first_resource, second_resource):
+        """
+        Recursively compares lists contents equivalence, ignoring types and element orders.
+        Lists with same size are compared value by value after a sort,
+        each element is converted to str before the comparison.
+        Args:
+            first_resource: first list
+            second_resource: second list
+
+        Returns:
+            True when equal;
+            False when different.
+        """
+
+        resource1 = deepcopy(first_resource)
+        resource2 = deepcopy(second_resource)
+
+        debug_resources = "resource1 = {0}, resource2 = {1}".format(resource1, resource2)
+
+        # The second list is null / empty  / False
+        if not resource2:
+            logger.debug("resource 2 is null. " + debug_resources)
+            return False
+
+        if len(resource1) != len(resource2):
+            logger.debug("resources have different length. " + debug_resources)
+            return False
+
+        resource1 = sorted(resource1, key=ResourceComparator._str_sorted)
+        resource2 = sorted(resource2, key=ResourceComparator._str_sorted)
+
+        for i, val in enumerate(resource1):
+            if isinstance(val, dict):
+                # change comparison function to compare dictionaries
+                if not ResourceComparator.compare(val, resource2[i]):
+                    logger.debug("resources are different. " + debug_resources)
+                    return False
+            elif isinstance(val, list):
+                # recursive call
+                if not ResourceComparator.compare_list(val, resource2[i]):
+                    logger.debug("lists are different. " + debug_resources)
+                    return False
+            elif ResourceComparator._standardize_value(val) != ResourceComparator._standardize_value(resource2[i]):
+                logger.debug("values are different. " + debug_resources)
+                return False
+
+        # no differences found
+        return True
+
+    @staticmethod
+    def _str_sorted(obj):
+        if isinstance(obj, dict):
+            return json.dumps(obj, sort_keys=True)
+        else:
+            return str(obj)
+
+    @staticmethod
+    def _standardize_value(value):
+        """
+        Convert value to string to enhance the comparison.
+
+        Args:
+            value: Any object type.
+
+        Returns:
+            str: Converted value.
+        """
+        if isinstance(value, float) and value.is_integer():
+            # Workaround to avoid erroneous comparison between int and float
+            # Removes zero from integer floats
+            value = int(value)
+
+        return str(value)
+
+
+class ResourceMerger():
+    @staticmethod
+    def merge_list_by_key(original_list, updated_list, key, ignore_when_null=[]):
+        """
+        Merge two lists by the key. It basically:
+        1. Adds the items that are present on updated_list and are absent on original_list.
+        2. Removes items that are absent on updated_list and are present on original_list.
+        3. For all items that are in both lists, overwrites the values from the original item by the updated item.
+
+        Args:
+            original_list: original list.
+            updated_list: list with changes.
+            key: unique identifier.
+            ignore_when_null: list with the keys from the updated items that should be ignored in the merge, if its
+            values are null.
+        Returns:
+            list: Lists merged.
+        """
+        if not original_list:
+            return updated_list
+
+        items_map = OrderedDict([(i[key], i.copy()) for i in original_list])
+
+        merged_items = OrderedDict()
+
+        for item in updated_list:
+            item_key = item[key]
+            if item_key in items_map:
+                for ignored_key in ignore_when_null:
+                    if ignored_key in item and not item[ignored_key]:
+                        item.pop(ignored_key)
+                merged_items[item_key] = items_map[item_key].copy()
+                merged_items[item_key].update(item)
+            else:
+                merged_items[item_key] = item.copy()
+
+        return [val for (_, val) in merged_items.items()]
+
+
+class SPKeys(object):
+    ID = 'id'
+    NAME = 'name'
+    DEVICE_SLOT = 'deviceSlot'
+    CONNECTIONS = 'connections'
+    OS_DEPLOYMENT = 'osDeploymentSettings'
+    OS_DEPLOYMENT_URI = 'osDeploymentPlanUri'
+    ATTRIBUTES = 'osCustomAttributes'
+    SAN = 'sanStorage'
+    VOLUMES = 'volumeAttachments'
+    PATHS = 'storagePaths'
+    CONN_ID = 'connectionId'
+    BOOT = 'boot'
+    BIOS = 'bios'
+    BOOT_MODE = 'bootMode'
+    LOCAL_STORAGE = 'localStorage'
+    SAS_LOGICAL_JBODS = 'sasLogicalJBODs'
+    CONTROLLERS = 'controllers'
+    LOGICAL_DRIVES = 'logicalDrives'
+    SAS_LOGICAL_JBOD_URI = 'sasLogicalJBODUri'
+    SAS_LOGICAL_JBOD_ID = 'sasLogicalJBODId'
+    MODE = 'mode'
+    MAC_TYPE = 'macType'
+    MAC = 'mac'
+    SERIAL_NUMBER_TYPE = 'serialNumberType'
+    UUID = 'uuid'
+    SERIAL_NUMBER = 'serialNumber'
+    DRIVE_NUMBER = 'driveNumber'
+    WWPN_TYPE = 'wwpnType'
+    WWNN = 'wwnn'
+    WWPN = 'wwpn'
+    LUN_TYPE = 'lunType'
+    LUN = 'lun'
+
+
+class ServerProfileMerger(object):
+    def merge_data(self, resource, data):
+        merged_data = deepcopy(resource)
+        merged_data.update(data)
+
+        merged_data = self._merge_bios_and_boot(merged_data, resource, data)
+        merged_data = self._merge_connections(merged_data, resource, data)
+        merged_data = self._merge_san_storage(merged_data, data, resource)
+        merged_data = self._merge_os_deployment_settings(merged_data, resource, data)
+        merged_data = self._merge_local_storage(merged_data, resource, data)
+
+        return merged_data
+
+    def _merge_bios_and_boot(self, merged_data, resource, data):
+        if self._should_merge(data, resource, key=SPKeys.BIOS):
+            merged_data = self._merge_dict(merged_data, resource, data, key=SPKeys.BIOS)
+        if self._should_merge(data, resource, key=SPKeys.BOOT):
+            merged_data = self._merge_dict(merged_data, resource, data, key=SPKeys.BOOT)
+        if self._should_merge(data, resource, key=SPKeys.BOOT_MODE):
+            merged_data = self._merge_dict(merged_data, resource, data, key=SPKeys.BOOT_MODE)
+        return merged_data
+
+    def _merge_connections(self, merged_data, resource, data):
+        if self._should_merge(data, resource, key=SPKeys.CONNECTIONS):
+            existing_connections = resource[SPKeys.CONNECTIONS]
+            params_connections = data[SPKeys.CONNECTIONS]
+            merged_data[SPKeys.CONNECTIONS] = ResourceMerger.merge_list_by_key(existing_connections,
+                                                                               params_connections,
+                                                                               key=SPKeys.ID)
+
+            merged_data = self._merge_connections_boot(merged_data, resource)
+        return merged_data
+
+    def _merge_connections_boot(self, merged_data, resource):
+        existing_connection_map = {x[SPKeys.ID]: x.copy() for x in resource[SPKeys.CONNECTIONS]}
+        for merged_connection in merged_data[SPKeys.CONNECTIONS]:
+            conn_id = merged_connection[SPKeys.ID]
+            existing_conn_has_boot = conn_id in existing_connection_map and SPKeys.BOOT in existing_connection_map[
+                conn_id]
+            if existing_conn_has_boot and SPKeys.BOOT in merged_connection:
+                current_connection = existing_connection_map[conn_id]
+                boot_settings_merged = deepcopy(current_connection[SPKeys.BOOT])
+                boot_settings_merged.update(merged_connection[SPKeys.BOOT])
+                merged_connection[SPKeys.BOOT] = boot_settings_merged
+        return merged_data
+
+    def _merge_san_storage(self, merged_data, data, resource):
+        if self._removed_data(data, resource, key=SPKeys.SAN):
+            merged_data[SPKeys.SAN] = dict(volumeAttachments=[], manageSanStorage=False)
+        elif self._should_merge(data, resource, key=SPKeys.SAN):
+            merged_data = self._merge_dict(merged_data, resource, data, key=SPKeys.SAN)
+
+            merged_data = self._merge_san_volumes(merged_data, resource, data)
+        return merged_data
+
+    def _merge_san_volumes(self, merged_data, resource, data):
+        if self._should_merge(data[SPKeys.SAN], resource[SPKeys.SAN], key=SPKeys.VOLUMES):
+            existing_volumes = resource[SPKeys.SAN][SPKeys.VOLUMES]
+            params_volumes = data[SPKeys.SAN][SPKeys.VOLUMES]
+            merged_volumes = ResourceMerger.merge_list_by_key(existing_volumes, params_volumes, key=SPKeys.ID)
+            merged_data[SPKeys.SAN][SPKeys.VOLUMES] = merged_volumes
+
+            merged_data = self._merge_san_storage_paths(merged_data, resource)
+        return merged_data
+
+    def _merge_san_storage_paths(self, merged_data, resource):
+
+        existing_volumes_map = OrderedDict([(i[SPKeys.ID], i) for i in resource[SPKeys.SAN][SPKeys.VOLUMES]])
+        merged_volumes = merged_data[SPKeys.SAN][SPKeys.VOLUMES]
+        for merged_volume in merged_volumes:
+            volume_id = merged_volume[SPKeys.ID]
+            if volume_id in existing_volumes_map:
+                if SPKeys.PATHS in merged_volume and SPKeys.PATHS in existing_volumes_map[volume_id]:
+                    existent_paths = existing_volumes_map[volume_id][SPKeys.PATHS]
+
+                    paths_from_merged_volume = merged_volume[SPKeys.PATHS]
+
+                    merged_paths = ResourceMerger.merge_list_by_key(existent_paths,
+                                                                    paths_from_merged_volume,
+                                                                    key=SPKeys.CONN_ID)
+
+                    merged_volume[SPKeys.PATHS] = merged_paths
+        return merged_data
+
+    def _merge_os_deployment_settings(self, merged_data, resource, data):
+        if self._should_merge(data, resource, key=SPKeys.OS_DEPLOYMENT):
+            merged_data = self._merge_dict(merged_data, resource, data, key=SPKeys.OS_DEPLOYMENT)
+
+            merged_data = self._merge_os_deployment_custom_attr(merged_data, resource, data)
+        return merged_data
+
+    def _merge_os_deployment_custom_attr(self, merged_data, resource, data):
+        if SPKeys.ATTRIBUTES in data[SPKeys.OS_DEPLOYMENT]:
+            existing_os_deployment = resource[SPKeys.OS_DEPLOYMENT]
+            params_os_deployment = data[SPKeys.OS_DEPLOYMENT]
+            merged_os_deployment = merged_data[SPKeys.OS_DEPLOYMENT]
+
+            if self._removed_data(params_os_deployment, existing_os_deployment, key=SPKeys.ATTRIBUTES):
+                merged_os_deployment[SPKeys.ATTRIBUTES] = params_os_deployment[SPKeys.ATTRIBUTES]
+            else:
+                existing_attributes = existing_os_deployment[SPKeys.ATTRIBUTES]
+                params_attributes = params_os_deployment[SPKeys.ATTRIBUTES]
+
+                if ResourceComparator.compare_list(existing_attributes, params_attributes):
+                    merged_os_deployment[SPKeys.ATTRIBUTES] = existing_attributes
+
+        return merged_data
+
+    def _merge_local_storage(self, merged_data, resource, data):
+        if self._removed_data(data, resource, key=SPKeys.LOCAL_STORAGE):
+            merged_data[SPKeys.LOCAL_STORAGE] = dict(sasLogicalJBODs=[], controllers=[])
+        elif self._should_merge(data, resource, key=SPKeys.LOCAL_STORAGE):
+            merged_data = self._merge_sas_logical_jbods(merged_data, resource, data)
+            merged_data = self._merge_controllers(merged_data, resource, data)
+        return merged_data
+
+    def _merge_sas_logical_jbods(self, merged_data, resource, data):
+        if self._should_merge(data[SPKeys.LOCAL_STORAGE], resource[SPKeys.LOCAL_STORAGE], key=SPKeys.SAS_LOGICAL_JBODS):
+            existing_items = resource[SPKeys.LOCAL_STORAGE][SPKeys.SAS_LOGICAL_JBODS]
+            provided_items = merged_data[SPKeys.LOCAL_STORAGE][SPKeys.SAS_LOGICAL_JBODS]
+            merged_jbods = ResourceMerger.merge_list_by_key(existing_items,
+                                                            provided_items,
+                                                            key=SPKeys.ID,
+                                                            ignore_when_null=[SPKeys.SAS_LOGICAL_JBOD_URI])
+            merged_data[SPKeys.LOCAL_STORAGE][SPKeys.SAS_LOGICAL_JBODS] = merged_jbods
+        return merged_data
+
+    def _merge_controllers(self, merged_data, resource, data):
+        if self._should_merge(data[SPKeys.LOCAL_STORAGE], resource[SPKeys.LOCAL_STORAGE], key=SPKeys.CONTROLLERS):
+            existing_items = resource[SPKeys.LOCAL_STORAGE][SPKeys.CONTROLLERS]
+            provided_items = merged_data[SPKeys.LOCAL_STORAGE][SPKeys.CONTROLLERS]
+            merged_controllers = ResourceMerger.merge_list_by_key(existing_items,
+                                                                  provided_items,
+                                                                  key=SPKeys.DEVICE_SLOT)
+            merged_data[SPKeys.LOCAL_STORAGE][SPKeys.CONTROLLERS] = merged_controllers
+
+            merged_data = self._merge_controller_drives(merged_data, resource)
+        return merged_data
+
+    def _merge_controller_drives(self, merged_data, resource):
+        for current_controller in merged_data[SPKeys.LOCAL_STORAGE][SPKeys.CONTROLLERS][:]:
+            for existing_controller in resource[SPKeys.LOCAL_STORAGE][SPKeys.CONTROLLERS][:]:
+                same_slot = current_controller.get(SPKeys.DEVICE_SLOT) == existing_controller.get(SPKeys.DEVICE_SLOT)
+                same_mode = existing_controller.get(SPKeys.MODE) == existing_controller.get(SPKeys.MODE)
+                if same_slot and same_mode and current_controller[SPKeys.LOGICAL_DRIVES]:
+
+                    key_merge = self._define_key_to_merge_drives(current_controller)
+
+                    if key_merge:
+                        merged_drives = ResourceMerger.merge_list_by_key(existing_controller[SPKeys.LOGICAL_DRIVES],
+                                                                         current_controller[SPKeys.LOGICAL_DRIVES],
+                                                                         key=key_merge)
+                        current_controller[SPKeys.LOGICAL_DRIVES] = merged_drives
+        return merged_data
+
+    def _define_key_to_merge_drives(self, controller):
+        has_name = True
+        has_logical_jbod_id = True
+        for drive in controller[SPKeys.LOGICAL_DRIVES]:
+            if not drive.get(SPKeys.NAME):
+                has_name = False
+            if not drive.get(SPKeys.SAS_LOGICAL_JBOD_ID):
+                has_logical_jbod_id = False
+
+        if has_name:
+            return SPKeys.NAME
+        elif has_logical_jbod_id:
+            return SPKeys.SAS_LOGICAL_JBOD_ID
+        return None
+
+    def _removed_data(self, data, resource, key):
+        return key in data and not data[key] and key in resource
+
+    def _should_merge(self, data, resource, key):
+        data_has_value = key in data and data[key]
+        existing_resource_has_value = key in resource and resource[key]
+        return data_has_value and existing_resource_has_value
+
+    def _merge_dict(self, merged_data, resource, data, key):
+        if resource[key]:
+            merged_dict = deepcopy(resource[key])
+            merged_dict.update(deepcopy(data[key]))
+        merged_data[key] = merged_dict
+        return merged_data
+
+
+class ServerProfileReplaceNamesByUris(object):
+    SERVER_PROFILE_OS_DEPLOYMENT_NOT_FOUND = 'OS Deployment Plan not found: '
+    SERVER_PROFILE_ENCLOSURE_GROUP_NOT_FOUND = 'Enclosure Group not found: '
+    SERVER_PROFILE_NETWORK_NOT_FOUND = 'Network not found: '
+    SERVER_HARDWARE_TYPE_NOT_FOUND = 'Server Hardware Type not found: '
+    VOLUME_NOT_FOUND = 'Volume not found: '
+    STORAGE_POOL_NOT_FOUND = 'Storage Pool not found: '
+    STORAGE_SYSTEM_NOT_FOUND = 'Storage System not found: '
+    INTERCONNECT_NOT_FOUND = 'Interconnect not found: '
+    FIRMWARE_DRIVER_NOT_FOUND = 'Firmware Driver not found: '
+    SAS_LOGICAL_JBOD_NOT_FOUND = 'SAS logical JBOD not found: '
+    ENCLOSURE_NOT_FOUND = 'Enclosure not found: '
+
+    def replace(self, oneview_client, data):
+        self.oneview_client = oneview_client
+        self.__replace_os_deployment_name_by_uri(data)
+        self.__replace_enclosure_group_name_by_uri(data)
+        self.__replace_networks_name_by_uri(data)
+        self.__replace_server_hardware_type_name_by_uri(data)
+        self.__replace_volume_attachment_names_by_uri(data)
+        self.__replace_enclosure_name_by_uri(data)
+        self.__replace_interconnect_name_by_uri(data)
+        self.__replace_firmware_baseline_name_by_uri(data)
+        self.__replace_sas_logical_jbod_name_by_uri(data)
+
+    def __replace_name_by_uri(self, data, attr_name, message, resource_client):
+        attr_uri = attr_name.replace("Name", "Uri")
+        if attr_name in data:
+            name = data.pop(attr_name)
+            resource_by_name = resource_client.get_by('name', name)
+            if not resource_by_name:
+                raise HPOneViewResourceNotFound(message + name)
+            data[attr_uri] = resource_by_name[0]['uri']
+
+    def __replace_os_deployment_name_by_uri(self, data):
+        if SPKeys.OS_DEPLOYMENT in data and data[SPKeys.OS_DEPLOYMENT]:
+            self.__replace_name_by_uri(data[SPKeys.OS_DEPLOYMENT], 'osDeploymentPlanName',
+                                       self.SERVER_PROFILE_OS_DEPLOYMENT_NOT_FOUND,
+                                       self.oneview_client.os_deployment_plans)
+
+    def __replace_enclosure_group_name_by_uri(self, data):
+        self.__replace_name_by_uri(data, 'enclosureGroupName', self.SERVER_PROFILE_ENCLOSURE_GROUP_NOT_FOUND,
+                                   self.oneview_client.enclosure_groups)
+
+    def __replace_networks_name_by_uri(self, data):
+        if SPKeys.CONNECTIONS in data and data[SPKeys.CONNECTIONS]:
+            for connection in data[SPKeys.CONNECTIONS]:
+                if 'networkName' in connection:
+                    name = connection.pop('networkName', None)
+                    connection['networkUri'] = self.__get_network_by_name(name)['uri']
+
+    def __replace_server_hardware_type_name_by_uri(self, data):
+        self.__replace_name_by_uri(data, 'serverHardwareTypeName', self.SERVER_HARDWARE_TYPE_NOT_FOUND,
+                                   self.oneview_client.server_hardware_types)
+
+    def __replace_volume_attachment_names_by_uri(self, data):
+        volume_attachments = (data.get('sanStorage') or {}).get('volumeAttachments') or []
+        if len(volume_attachments) > 0:
+            for volume in volume_attachments:
+                self.__replace_name_by_uri(volume, 'volumeName', self.VOLUME_NOT_FOUND, self.oneview_client.volumes)
+                self.__replace_name_by_uri(volume, 'volumeStoragePoolName', self.STORAGE_POOL_NOT_FOUND,
+                                           self.oneview_client.storage_pools)
+                self.__replace_name_by_uri(volume, 'volumeStorageSystemName', self.STORAGE_SYSTEM_NOT_FOUND,
+                                           self.oneview_client.storage_systems)
+
+    def __replace_enclosure_name_by_uri(self, data):
+        self.__replace_name_by_uri(data, 'enclosureName', self.ENCLOSURE_NOT_FOUND, self.oneview_client.enclosures)
+
+    def __replace_interconnect_name_by_uri(self, data):
+        connections = data.get('connections') or []
+        if len(connections) > 0:
+            for connection in connections:
+                self.__replace_name_by_uri(connection, 'interconnectName', self.INTERCONNECT_NOT_FOUND,
+                                           self.oneview_client.interconnects)
+
+    def __replace_firmware_baseline_name_by_uri(self, data):
+        firmware = data.get('firmware') or {}
+        self.__replace_name_by_uri(firmware, 'firmwareBaselineName', self.FIRMWARE_DRIVER_NOT_FOUND,
+                                   self.oneview_client.firmware_drivers)
+
+    def __replace_sas_logical_jbod_name_by_uri(self, data):
+        sas_logical_jbods = (data.get('localStorage') or {}).get('sasLogicalJBODs') or []
+        if len(sas_logical_jbods) > 0:
+            for jbod in sas_logical_jbods:
+                self.__replace_name_by_uri(jbod, 'sasLogicalJBODName', self.SAS_LOGICAL_JBOD_NOT_FOUND,
+                                           self.oneview_client.sas_logical_jbods)
+
+    def __get_network_by_name(self, name):
+        fc_networks = self.oneview_client.fc_networks.get_by('name', name)
+        if fc_networks:
+            return fc_networks[0]
+
+        ethernet_networks = self.oneview_client.ethernet_networks.get_by('name', name)
+        if not ethernet_networks:
+            raise HPOneViewResourceNotFound(self.SERVER_PROFILE_NETWORK_NOT_FOUND + name)
+        return ethernet_networks[0]

--- a/lib/ansible/modules/cloud/hpe/oneview_fc_network.py
+++ b/lib/ansible/modules/cloud/hpe/oneview_fc_network.py
@@ -1,0 +1,121 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (2016-2017) Hewlett Packard Enterprise Development LP
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['stableinterface'],
+                    'supported_by': 'curated'}
+
+DOCUMENTATION = '''
+---
+module: oneview_fc_network
+short_description: Manage OneView Fibre Channel Network resources.
+description:
+    - Provides an interface to manage Fibre Channel Network resources. Can create, update, and delete.
+version_added: "2.4"
+requirements:
+    - "python >= 2.7.9"
+    - "hpOneView >= 3.1.0"
+author: "Bruno Souza (@bsouza)"
+options:
+    state:
+        description:
+            - Indicates the desired state for the Fibre Channel Network resource.
+              C(present) will ensure data properties are compliant with OneView.
+              C(absent) will remove the resource from OneView, if it exists.
+        choices: ['present', 'absent']
+    data:
+        description:
+            - List with the Fibre Channel Network properties.
+        required: true
+
+extends_documentation_fragment:
+    - oneview
+    - oneview.validateetag
+'''
+
+EXAMPLES = '''
+- name: Ensure that the Fibre Channel Network is present using the default configuration
+  oneview_fc_network:
+    config: "{{ config_file_path }}"
+    state: present
+    data:
+      name: 'New FC Network'
+
+- name: Ensure that the Fibre Channel Network is present with fabricType 'DirectAttach'
+  oneview_fc_network:
+    config: "{{ config_file_path }}"
+    state: present
+    data:
+      name: 'New FC Network'
+      fabricType: 'DirectAttach'
+
+- name: Ensure that the Fibre Channel Network is absent
+  oneview_fc_network:
+    config: "{{ config_file_path }}"
+    state: absent
+    data:
+      name: 'New FC Network'
+'''
+
+RETURN = '''
+fc_network:
+    description: Has the facts about the managed OneView FC Network.
+    returned: On state 'present'. Can be null.
+    type: complex
+    contains: FC Network data
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.oneview import OneViewModuleBase
+
+
+class FcNetworkModule(OneViewModuleBase):
+    MSG_CREATED = 'FC Network created successfully.'
+    MSG_UPDATED = 'FC Network updated successfully.'
+    MSG_DELETED = 'FC Network deleted successfully.'
+    MSG_ALREADY_PRESENT = 'FC Network is already present.'
+    MSG_ALREADY_ABSENT = 'FC Network is already absent.'
+    RESOURCE_FACT_NAME = 'fc_network'
+
+    def __init__(self):
+
+        additional_arg_spec = dict(data=dict(required=True, type='dict'),
+                                   state=dict(
+                                       required=True,
+                                       choices=['present', 'absent']))
+
+        super(FcNetworkModule, self).__init__(additional_arg_spec=additional_arg_spec,
+                                              validate_etag_support=True)
+
+        self.resource_client = self.oneview_client.fc_networks
+
+    def execute_module(self):
+        resource = self.get_by_name(self.data['name'])
+
+        if self.state == 'present':
+            return self.resource_present(resource, self.RESOURCE_FACT_NAME)
+        elif self.state == 'absent':
+            return self.resource_absent(resource)
+
+
+def main():
+    FcNetworkModule().run()
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/hpe/oneview_fc_network.py
+++ b/lib/ansible/modules/cloud/hpe/oneview_fc_network.py
@@ -18,7 +18,7 @@
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['stableinterface'],
-                    'supported_by': 'curated'}
+                    'supported_by': 'community'}
 
 DOCUMENTATION = '''
 ---

--- a/lib/ansible/modules/cloud/hpe/oneview_fc_network_facts.py
+++ b/lib/ansible/modules/cloud/hpe/oneview_fc_network_facts.py
@@ -17,7 +17,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 ANSIBLE_METADATA = {'status': ['stableinterface'],
-                    'supported_by': 'curated',
+                    'supported_by': 'community',
                     'metadata_version': '1.0'}
 
 DOCUMENTATION = '''

--- a/lib/ansible/modules/cloud/hpe/oneview_fc_network_facts.py
+++ b/lib/ansible/modules/cloud/hpe/oneview_fc_network_facts.py
@@ -1,0 +1,108 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (2016-2017) Hewlett Packard Enterprise Development LP
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+ANSIBLE_METADATA = {'status': ['stableinterface'],
+                    'supported_by': 'curated',
+                    'metadata_version': '1.0'}
+
+DOCUMENTATION = '''
+---
+module: oneview_fc_network_facts
+short_description: Retrieve the facts about one or more of the OneView Fibre Channel Networks.
+description:
+    - Retrieve the facts about one or more of the Fibre Channel Networks from OneView.
+version_added: "2.4"
+requirements:
+    - "python >= 2.7.9"
+    - "hpOneView >= 2.0.1"
+author:
+    "Mariana Kreisig (@marikrg)"
+options:
+    name:
+      description:
+        - Fibre Channel Network name.
+      required: false
+
+extends_documentation_fragment:
+    - oneview
+    - oneview.factsparams
+'''
+
+EXAMPLES = '''
+- name: Gather facts about all Fibre Channel Networks
+  oneview_fc_network_facts:
+    config: "{{ config_file_path }}"
+
+- debug: var=fc_networks
+
+- name: Gather paginated, filtered and sorted facts about Fibre Channel Networks
+  oneview_fc_network_facts:
+    config: "{{ config }}"
+    params:
+      start: 1
+      count: 3
+      sort: 'name:descending'
+      filter: 'fabricType=FabricAttach'
+- debug: var=fc_networks
+
+- name: Gather facts about a Fibre Channel Network by name
+  oneview_fc_network_facts:
+    config: "{{ config_file_path }}"
+    name: network name
+
+- debug: var=fc_networks
+'''
+
+RETURN = '''
+fc_networks:
+    description: Has all the OneView facts about the Fibre Channel Networks.
+    returned: Always, but can be null.
+    type: complex
+    contains: All parameters for the retrieved Fibre Channel Networks.
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.oneview import OneViewModuleBase
+
+
+class FcNetworkFactsModule(OneViewModuleBase):
+    def __init__(self):
+
+        argument_spec = dict(
+            name=dict(required=False, type='str'),
+            params=dict(required=False, type='dict')
+        )
+
+        super(FcNetworkFactsModule, self).__init__(additional_arg_spec=argument_spec)
+
+    def execute_module(self):
+
+        if self.module.params['name']:
+            fc_networks = self.oneview_client.fc_networks.get_by('name', self.module.params['name'])
+        else:
+            fc_networks = self.oneview_client.fc_networks.get_all(**self.facts_params)
+
+        return dict(changed=False, ansible_facts=dict(fc_networks=fc_networks))
+
+
+def main():
+    FcNetworkFactsModule().run()
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/utils/module_docs_fragments/oneview.py
+++ b/lib/ansible/utils/module_docs_fragments/oneview.py
@@ -1,0 +1,62 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (2016-2017) Hewlett Packard Enterprise Development LP
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+class ModuleDocFragment(object):
+
+    # OneView doc fragment
+    DOCUMENTATION = '''
+options:
+    config:
+      description:
+        - Path to a .json configuration file containing the OneView client configuration.
+          The configuration file is optional. If the file path is not provided, the configuration will be loaded from
+          environment variables.
+      required: false
+
+notes:
+    - "A sample configuration file for the config parameter can be found at:
+       U(https://github.com/HewlettPackard/oneview-ansible/blob/master/examples/oneview_config-rename.json)"
+    - "Check how to use environment variables for configuration at:
+       U(https://github.com/HewlettPackard/oneview-ansible#environment-variables)"
+    - "Additional Playbooks for the HPE OneView Ansible modules can be found at:
+       U(https://github.com/HewlettPackard/oneview-ansible/tree/master/examples)"
+    '''
+
+    VALIDATEETAG = '''
+options:
+    validate_etag:
+        description:
+            - When the ETag Validation is enabled, the request will be conditionally processed only if the current ETag
+                for the resource matches the ETag provided in the data.
+        default: true
+        choices: ['true', 'false']
+'''
+
+    FACTSPARAMS = '''
+options:
+    params:
+        description:
+        - List of params to delimit, filter and sort the list of resources.
+        - "params allowed:
+            C(start): The first item to return, using 0-based indexing.
+            C(count): The number of resources to return.
+            C(filter): A general filter/query string to narrow the list of items returned.
+            C(sort): The sort order of the returned data set."
+        required: false
+'''

--- a/test/runner/requirements/units.txt
+++ b/test/runner/requirements/units.txt
@@ -1,5 +1,6 @@
 boto
 boto3
+hpOneView ; python_version >= '2.7'
 placebo
 jinja2
 mock
@@ -21,6 +22,3 @@ ipaddress
 f5-sdk ; python_version >= '2.7'
 f5-icontrol-rest ; python_version >= '2.7'
 deepdiff
-
-# requirements for HPE OneView specific modules
-hpOneView

--- a/test/runner/requirements/units.txt
+++ b/test/runner/requirements/units.txt
@@ -16,6 +16,7 @@ setuptools > 0.6 # pytest-xdist installed via requirements does not work with ve
 unittest2 ; python_version < '2.7'
 netaddr
 ipaddress
+hpOneView
 
 # requirements for F5 specific modules
 f5-sdk ; python_version >= '2.7'

--- a/test/runner/requirements/units.txt
+++ b/test/runner/requirements/units.txt
@@ -16,9 +16,11 @@ setuptools > 0.6 # pytest-xdist installed via requirements does not work with ve
 unittest2 ; python_version < '2.7'
 netaddr
 ipaddress
-hpOneView
 
 # requirements for F5 specific modules
 f5-sdk ; python_version >= '2.7'
 f5-icontrol-rest ; python_version >= '2.7'
 deepdiff
+
+# requirements for HPE OneView specific modules
+hpOneView

--- a/test/units/modules/cloud/hpe/hpe_test_utils.py
+++ b/test/units/modules/cloud/hpe/hpe_test_utils.py
@@ -1,0 +1,136 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (2016-2017) Hewlett Packard Enterprise Development LP
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+import importlib
+import yaml
+from mock import Mock, patch
+from oneview_module_loader import ONEVIEW_MODULE_UTILS_PATH
+from hpOneView.oneview_client import OneViewClient
+
+
+class OneViewBaseTestCase(object):
+    mock_ov_client_from_json_file = None
+    testing_class = None
+    mock_ansible_module = None
+    mock_ov_client = None
+    testing_module = None
+    EXAMPLES = None
+
+    def configure_mocks(self, test_case, testing_class):
+        """
+        Preload mocked OneViewClient instance and AnsibleModule
+        Args:
+            test_case (object): class instance (self) that are inheriting from OneViewBaseTestCase
+            testing_class (object): class being tested
+        """
+        self.testing_class = testing_class
+
+        # Define OneView Client Mock (FILE)
+        patcher_json_file = patch.object(OneViewClient, 'from_json_file')
+        test_case.addCleanup(patcher_json_file.stop)
+        self.mock_ov_client_from_json_file = patcher_json_file.start()
+
+        # Define OneView Client Mock
+        self.mock_ov_client = self.mock_ov_client_from_json_file.return_value
+
+        # Define Ansible Module Mock
+        patcher_ansible = patch(ONEVIEW_MODULE_UTILS_PATH + '.AnsibleModule')
+        test_case.addCleanup(patcher_ansible.stop)
+        mock_ansible_module = patcher_ansible.start()
+        self.mock_ansible_module = Mock()
+        mock_ansible_module.return_value = self.mock_ansible_module
+
+        self.__set_module_examples()
+
+    def test_main_function_should_call_run_method(self):
+        self.mock_ansible_module.params = {'config': 'config.json'}
+
+        main_func = getattr(self.testing_module, 'main')
+
+        with patch.object(self.testing_class, "run") as mock_run:
+            main_func()
+            mock_run.assert_called_once()
+
+    def __set_module_examples(self):
+        self.testing_module = importlib.import_module(self.testing_class.__module__)
+
+        try:
+            # Load scenarios from module examples (Also checks if it is a valid yaml)
+            self.EXAMPLES = yaml.load(self.testing_module.EXAMPLES, yaml.SafeLoader)
+
+        except yaml.scanner.ScannerError:
+            message = "Something went wrong while parsing yaml from {}.EXAMPLES".format(self.testing_class.__module__)
+            raise Exception(message)
+
+
+class FactsParamsTestCase(OneViewBaseTestCase):
+    """
+    FactsParamsTestCase has common test for classes that support pass additional
+        parameters when retrieving all resources.
+    """
+
+    def configure_client_mock(self, resorce_client):
+        """
+        Args:
+             resorce_client: Resource client that is being called
+        """
+        self.resource_client = resorce_client
+
+    def __validations(self):
+        if not self.testing_class:
+            raise Exception("Mocks are not configured, you must call 'configure_mocks' before running this test.")
+
+        if not self.resource_client:
+            raise Exception(
+                "Mock for the client not configured, you must call 'configure_client_mock' before running this test.")
+
+    def test_should_get_all_using_filters(self):
+        self.__validations()
+        self.resource_client.get_all.return_value = []
+
+        params_get_all_with_filters = dict(
+            config='config.json',
+            name=None,
+            params={
+                'start': 1,
+                'count': 3,
+                'sort': 'name:descending',
+                'filter': 'purpose=General',
+                'query': 'imported eq true'
+            })
+        self.mock_ansible_module.params = params_get_all_with_filters
+
+        self.testing_class().run()
+
+        self.resource_client.get_all.assert_called_once_with(start=1, count=3, sort='name:descending',
+                                                             filter='purpose=General',
+                                                             query='imported eq true')
+
+    def test_should_get_all_without_params(self):
+        self.__validations()
+        self.resource_client.get_all.return_value = []
+
+        params_get_all_with_filters = dict(
+            config='config.json',
+            name=None
+        )
+        self.mock_ansible_module.params = params_get_all_with_filters
+
+        self.testing_class().run()
+
+        self.resource_client.get_all.assert_called_once_with()

--- a/test/units/modules/cloud/hpe/oneview_module_loader.py
+++ b/test/units/modules/cloud/hpe/oneview_module_loader.py
@@ -1,0 +1,35 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (2016-2017) Hewlett Packard Enterprise Development LP
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+"""
+This module was created because the code in this repository is shared with Ansible Core.
+So, to avoid merging issues, and maintaining the tests code equal, we create a unique file to
+configure the imports that change from ansible.modules.cloud.hpe.one repository to another.
+"""
+
+ONEVIEW_MODULE_UTILS_PATH = 'ansible.module_utils.oneview'
+
+from ansible.module_utils.oneview import (HPOneViewException,
+                                          HPOneViewTaskError,
+                                          OneViewModuleBase,
+                                          SPKeys,
+                                          ServerProfileMerger,
+                                          ServerProfileReplaceNamesByUris,
+                                          ResourceComparator)
+
+from ansible.modules.cloud.hpe.oneview_fc_network import FcNetworkModule
+from ansible.modules.cloud.hpe.oneview_fc_network_facts import FcNetworkFactsModule

--- a/test/units/modules/cloud/hpe/test_oneview_fc_network.py
+++ b/test/units/modules/cloud/hpe/test_oneview_fc_network.py
@@ -1,0 +1,134 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (2016-2017) Hewlett Packard Enterprise Development LP
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from oneview_module_loader import FcNetworkModule
+from hpe_test_utils import OneViewBaseTestCase
+
+FAKE_MSG_ERROR = 'Fake message error'
+
+DEFAULT_FC_NETWORK_TEMPLATE = dict(
+    name='New FC Network 2',
+    autoLoginRedistribution=True,
+    fabricType='FabricAttach'
+)
+
+PARAMS_FOR_PRESENT = dict(
+    config='config.json',
+    state='present',
+    data=dict(name=DEFAULT_FC_NETWORK_TEMPLATE['name'])
+)
+
+PARAMS_WITH_CHANGES = dict(
+    config='config.json',
+    state='present',
+    data=dict(name=DEFAULT_FC_NETWORK_TEMPLATE['name'],
+              newName="New Name",
+              fabricType='DirectAttach')
+)
+
+PARAMS_FOR_ABSENT = dict(
+    config='config.json',
+    state='absent',
+    data=dict(name=DEFAULT_FC_NETWORK_TEMPLATE['name'])
+)
+
+
+class FcNetworkModuleSpec(unittest.TestCase,
+                          OneViewBaseTestCase):
+    """
+    OneViewBaseTestCase provides the mocks used in this test case
+    """
+
+    def setUp(self):
+        self.configure_mocks(self, FcNetworkModule)
+        self.resource = self.mock_ov_client.fc_networks
+
+    def test_should_create_new_fc_network(self):
+        self.resource.get_by.return_value = []
+        self.resource.create.return_value = DEFAULT_FC_NETWORK_TEMPLATE
+
+        self.mock_ansible_module.params = PARAMS_FOR_PRESENT
+
+        FcNetworkModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=True,
+            msg=FcNetworkModule.MSG_CREATED,
+            ansible_facts=dict(fc_network=DEFAULT_FC_NETWORK_TEMPLATE)
+        )
+
+    def test_should_not_update_when_data_is_equals(self):
+        self.resource.get_by.return_value = [DEFAULT_FC_NETWORK_TEMPLATE]
+
+        self.mock_ansible_module.params = PARAMS_FOR_PRESENT
+
+        FcNetworkModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            msg=FcNetworkModule.MSG_ALREADY_PRESENT,
+            ansible_facts=dict(fc_network=DEFAULT_FC_NETWORK_TEMPLATE)
+        )
+
+    def test_update_when_data_has_modified_attributes(self):
+        data_merged = DEFAULT_FC_NETWORK_TEMPLATE.copy()
+
+        data_merged['fabricType'] = 'DirectAttach'
+
+        self.resource.get_by.return_value = [DEFAULT_FC_NETWORK_TEMPLATE]
+        self.resource.update.return_value = data_merged
+
+        self.mock_ansible_module.params = PARAMS_WITH_CHANGES
+
+        FcNetworkModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=True,
+            msg=FcNetworkModule.MSG_UPDATED,
+            ansible_facts=dict(fc_network=data_merged)
+        )
+
+    def test_should_remove_fc_network(self):
+        self.resource.get_by.return_value = [DEFAULT_FC_NETWORK_TEMPLATE]
+
+        self.mock_ansible_module.params = PARAMS_FOR_ABSENT
+
+        FcNetworkModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=True,
+            msg=FcNetworkModule.MSG_DELETED
+        )
+
+    def test_should_do_nothing_when_fc_network_not_exist(self):
+        self.resource.get_by.return_value = []
+
+        self.mock_ansible_module.params = PARAMS_FOR_ABSENT
+
+        FcNetworkModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            msg=FcNetworkModule.MSG_ALREADY_ABSENT
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/units/modules/cloud/hpe/test_oneview_fc_network_facts.py
+++ b/test/units/modules/cloud/hpe/test_oneview_fc_network_facts.py
@@ -1,0 +1,73 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (2016-2017) Hewlett Packard Enterprise Development LP
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from oneview_module_loader import FcNetworkFactsModule
+from hpe_test_utils import FactsParamsTestCase
+
+ERROR_MSG = 'Fake message error'
+
+PARAMS_GET_ALL = dict(
+    config='config.json',
+    name=None
+)
+
+PARAMS_GET_BY_NAME = dict(
+    config='config.json',
+    name="Test FC Network"
+)
+
+PRESENT_NETWORKS = [{
+    "name": "Test FC Network",
+    "uri": "/rest/fc-networks/c6bf9af9-48e7-4236-b08a-77684dc258a5"
+}]
+
+
+class FcNetworkFactsSpec(unittest.TestCase,
+                         FactsParamsTestCase):
+    def setUp(self):
+        self.configure_mocks(self, FcNetworkFactsModule)
+        self.fc_networks = self.mock_ov_client.fc_networks
+        FactsParamsTestCase.configure_client_mock(self, self.fc_networks)
+
+    def test_should_get_all_fc_networks(self):
+        self.fc_networks.get_all.return_value = PRESENT_NETWORKS
+        self.mock_ansible_module.params = PARAMS_GET_ALL
+
+        FcNetworkFactsModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(fc_networks=PRESENT_NETWORKS)
+        )
+
+    def test_should_get_fc_network_by_name(self):
+        self.fc_networks.get_by.return_value = PRESENT_NETWORKS
+        self.mock_ansible_module.params = PARAMS_GET_BY_NAME
+
+        FcNetworkFactsModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(fc_networks=PRESENT_NETWORKS)
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/utils/tox/requirements-py3.txt
+++ b/test/utils/tox/requirements-py3.txt
@@ -14,3 +14,4 @@ python-systemd
 botocore
 boto3
 pytest
+hpOneView

--- a/test/utils/tox/requirements.txt
+++ b/test/utils/tox/requirements.txt
@@ -15,3 +15,4 @@ pycrypto
 botocore
 boto3
 pytest
+hpOneView


### PR DESCRIPTION
##### SUMMARY
HPE OneView is an infrastructure automation engine built with software intelligence. It streamlines provisioning and lifecycle management across compute, storage and fabric and enables IT staff to control resources programmatically through a unified API.

It is heavily focused on the DevOps workflow and has [many integrations](https://www.hpe.com/us/en/solutions/developers/composable.html) already, including an [ansible module](https://github.com/HewlettPackard/oneview-ansible) not integrated into core.

This PR aims to add the OneView base class to be used for all OneView resources, together with the modules for managing the [HPE OneView FC Network resource](http://h17007.www1.hpe.com/docs/enterprise/servers/oneview3.0/cic-api/en/api-docs/current/index.html#rest/fc-networks): `FcNetworkModule` and `FcNetworkFactsModule` and their unit tests.

This resource has the `present` and `absent` states which will manage all of its aspects, including creating and updating the resources (using `present`) and removal of resources (using `absent`).

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
`FcNetworkModule` and `FcNetworkFactsModule`

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel de4a8b83df) last updated 2017/06/22 18:57:00 (GMT +000)
  config file = None
  configured module search path = ['/home/vagrant/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/vagrant/temp/ansible/lib/ansible
  executable location = /home/vagrant/temp/ansible/bin/ansible
  python version = 3.5.3 (default, Jun 22 2017, 17:14:20) [GCC 4.8.4]
```


##### ADDITIONAL INFORMATION
Example of usage:
```yaml
    - name: Create a Fibre Channel Network
      oneview_fc_network:
        config: "{{ config }}"
        state: present
        validate_etag: false
        data:
          name: 'Test FC Network'
          fabricType: 'FabricAttach'
          linkStabilityTime: '30'
          autoLoginRedistribution: True
      delegate_to: localhost
      register: fc_network_1

    - name: Update the Fibre Channel Network changing the attribute autoLoginRedistribution to True
      oneview_fc_network:
        config: "{{ config }}"
        state: present
        data:
          name: 'Test FC Network'
          autoLoginRedistribution: True
          fabricType: 'FabricAttach'
          linkStabilityTime: '30'
      delegate_to: localhost

    - name: Delete the Fibre Channel Network
      oneview_fc_network:
        config: "{{ config }}"
        state: absent
        data: "{{ fc_network_1.ansible_facts.fc_network }}"
      delegate_to: localhost
      register: deleted
```
